### PR TITLE
Fixed bug w/ MacOS detection

### DIFF
--- a/lua/tables.lua
+++ b/lua/tables.lua
@@ -2,8 +2,8 @@ local Tables = {}
 
 local function system_icon()
 	if vim.fn.has("win32") == 1 then return "者"
-	elseif vim.fn.has("unix") == 1 then return " "
 	elseif vim.fn.has("mac") == 1 then return " "
+	elseif vim.fn.has("unix") == 1 then return " "
 	end
 end
 


### PR DESCRIPTION
## Problem
The status line brings up the Linux icon as the "cool_symbol" despite being on MacOS (or BSD).

## Solution
Checking if the user is using MacOS before checking if the user is using a unix-like operating system.

## Explanation
Since MacOS is technically a unix-like operating system, it's detected as such and since all unix-like operating systems are grouped up into being Linux distros, MacOS users will find the Linux icon as their "cool_symbol" instead of the Apple logo. 

To avoid this, we need to check if the user's operating system is MacOS before checking if it's a unix-like operating system as doing this prevents the program from detecting MacOS as Linux.

## Extra Notes
I plan on adding support for BSD and specific Linux distros (by specific I mean checking what Linux distro the user is using and then displaying the logo of that distro) as writing off all unix-like operating systems as just Linux isn't ideal (for me at least.) 