### PR TITLE
Add support for changing the git branch icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ PS: check out beta branch for new features like sections and lsp.
 	        cool_symbol      = " ",       -- Change this to override defult OS icon.
 	        filename_section = "center",   -- others: right, left, none or custom string.
 	        full_path        = false
-					branch_symbol    = " "
+		branch_symbol    = " "
 	    },
 	    mode_colors = {
 	        n = "#2bbb4f",

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ PS: check out beta branch for new features like sections and lsp.
 	        cool_symbol      = " ",       -- Change this to override defult OS icon.
 	        filename_section = "center",   -- others: right, left, none or custom string.
 	        full_path        = false
+					branch_symbol    = " "
 	    },
 	    mode_colors = {
 	        n = "#2bbb4f",

--- a/lua/staline.lua
+++ b/lua/staline.lua
@@ -28,9 +28,8 @@ local function get_branch()
 		command = 'git',
 		args = { 'branch', '--show-current' },
 	}):sync()[1]
-	return branch_name or ""
+	return branch_name and Tables.defaults.branch_symbol..branch_name or ""
 end
-local branch_name = get_branch()
 
 local function get_file_icon(f_name, ext)
 	if not pcall(require, 'nvim-web-devicons') then
@@ -72,7 +71,7 @@ function M.get_statusline(status)
 
 	local s_mode = '%#Staline#  '..modeIcon
 	local s_sep = '  %#Arrow#'..t.left_separator ..'%#MidArrow#'..t.left_separator
-	local s_branch = " %#BranchName#"..Tables.defaults.branch_symbol..branch_name.."  "
+	local s_branch = " %#BranchName#"..get_branch().."  "
 
 	local s_file = left..f_icon.."%#BranchName# "..f_name..edited.."%#MidArrow#"..right
 

--- a/lua/staline.lua
+++ b/lua/staline.lua
@@ -28,7 +28,7 @@ local function get_branch()
 		command = 'git',
 		args = { 'branch', '--show-current' },
 	}):sync()[1]
-	return branch_name and ' '..branch_name or ""
+	return branch_name or ""
 end
 local branch_name = get_branch()
 
@@ -72,7 +72,7 @@ function M.get_statusline(status)
 
 	local s_mode = '%#Staline#  '..modeIcon
 	local s_sep = '  %#Arrow#'..t.left_separator ..'%#MidArrow#'..t.left_separator
-	local s_branch = " %#BranchName#"..branch_name.."  "
+	local s_branch = " %#BranchName#"..Tables.defaults.branch_symbol..branch_name.."  "
 
 	local s_file = left..f_icon.."%#BranchName# "..f_name..edited.."%#MidArrow#"..right
 

--- a/lua/tables.lua
+++ b/lua/tables.lua
@@ -8,7 +8,7 @@ local function system_icon()
 end
 
 Tables = {
-		defaults = {
+	defaults = {
 		left_separator = "",
 		right_separator = "",
 		line_column = "[%l/%L] :%c 並%p%% ",
@@ -17,6 +17,7 @@ Tables = {
 		bg = "none",
 		full_path = false,
 		filename_section = "center",
+		branch_symbol = " "
 	},
 
 	mode_colors = {


### PR DESCRIPTION
## Issue
The current branch icon differed from the one I use in my terminal prompt and to change the branch icon, I would have to directly edit the source code.

## Solution and Explanation
Call a variable named "branch_symbol" located at [tables.lua#L20](https://github.com/is0n/staline.nvim/blob/main/lua/tables.lua#L20) when outputting the branch icon. The aforementioned variable can be modified by the user, therefore, adding support for changing the git branch icon.