### PR TITLE
Fix mode icon when in replace confirmation

### DIFF
--- a/lua/staline.lua
+++ b/lua/staline.lua
@@ -86,6 +86,7 @@ function M.get_statusline(status)
 
 	local mode = vim.api.nvim_get_mode()['mode']
 	local modeColor = status and Tables.mode_colors[mode] or t.inactive_color
+	local modeIcon = Tables.mode_icons[mode] or ""
 
 	local f_name = t.full_path and '%F' or '%t'
 	-- TODO: original color of icon
@@ -101,7 +102,7 @@ function M.get_statusline(status)
 		return "%#StalineInvert#%="..roger[2]..roger[1].."%="
 	end
 
-	M.sections['mode']             = (" "..Tables.mode_icons[mode].." ") or "  "
+	M.sections['mode']             = (" "..modeIcon.." ")
 	M.sections['branch']           = " "..(M.Branch_name or "").." "
 	M.sections['file_name']        = " "..f_icon.." "..f_name..edited.." "
 	M.sections['file_size']        = " " ..size.. "k "


### PR DESCRIPTION
Neovim enters in a special mode when confirming a replacement with
`:%s/patt/repl/gc` (the c is for confirmation).

This commit fixes it by fixing the default value of a mode icon.

## Before

![nvim-replace-problem-staline](https://user-images.githubusercontent.com/381213/132375840-d05082b3-e9a9-44e8-a5ca-87b4019fc362.png)

## After

![after-fixing-staline](https://user-images.githubusercontent.com/381213/132375861-ae0bee67-15c7-4b06-81fd-468cfdf6e654.png)

BTW, thank you for the project! :heart: 