### PR TITLE
add new option "inactive_bgcolor" for more control over inactive buffers statusline

### DIFF
--- a/lua/staline.lua
+++ b/lua/staline.lua
@@ -38,12 +38,12 @@ local function get_file_icon(f_name, ext)
 	return require'nvim-web-devicons'.get_icon(f_name, ext, {default = true})
 end
 
-local function call_highlights(modeColor)
-	vim.cmd('hi Staline guifg='..modeColor..' guibg='..t.bg..' gui='..t.font_active)
-	vim.cmd('hi StalineFill guibg='..modeColor..' guifg='..t.fg..' gui='..t.font_active)
-	vim.cmd('hi StalineNone guifg=none guibg='..t.bg)
-	vim.cmd('hi DoubleSep guifg='..modeColor..' guibg=#303030')
-	vim.cmd('hi MidSep guifg='.."#303030"..' guibg='..t.bg)
+local function call_highlights(fgColor, bgColor)
+	vim.cmd('hi Staline guifg='..fgColor..' guibg='..bgColor..' gui='..t.font_active)
+	vim.cmd('hi StalineFill guibg='..fgColor..' guifg='..t.fg..' gui='..t.font_active)
+	vim.cmd('hi StalineNone guifg=none guibg='..bgColor)
+	vim.cmd('hi DoubleSep guifg='..fgColor..' guibg=#303030')
+	vim.cmd('hi MidSep guifg='.."#303030"..' guibg='..bgColor)
 end
 
 local function get_lsp()
@@ -85,7 +85,8 @@ function M.get_statusline(status)
 	M.sections = {}
 
 	local mode = vim.api.nvim_get_mode()['mode']
-	local modeColor = status and Tables.mode_colors[mode] or t.inactive_color
+	local fgColor = status and Tables.mode_colors[mode] or t.inactive_color
+	local bgColor = status and t.bg or t.inactive_bgcolor
 	local modeIcon = Tables.mode_icons[mode] or ""
 
 	local f_name = t.full_path and '%F' or '%t'
@@ -95,7 +96,7 @@ function M.get_statusline(status)
 	-- TODO: need to support b, or mb
 	local size = string.format("%.1f", vim.fn.getfsize(vim.api.nvim_buf_get_name(0))/1024)
 
-	call_highlights(modeColor)
+	call_highlights(fgColor, bgColor)
 
 	local roger = Tables.special_table[vim.bo.ft]
 	if status and roger then

--- a/lua/tables.lua
+++ b/lua/tables.lua
@@ -26,6 +26,7 @@ Tables = {
 		full_path = false,
 		branch_symbol = " ",
 		inactive_color = "#303030",
+		inactive_bgcolor = "none",
 		font_active = "none",          -- bold,italic etc.
 		true_colors = false,
 		lsp_client_symbol = " "


### PR DESCRIPTION
I really like how simple and easy to use this plugin is, compared to the alternatives. The only thing I missed was being able to define the background color of the statusline in an inactive buffer, hence this pull request.

Below are some screenshots illustrating the changes.

With these settings:
```lua
require('stabline').setup {
  defaults = {
    bg = '#d5c4a1',
    inactive_color = 'gray',
    -- omitting irrelevant parts...
  },
  mode_colors = {
    ['n'] = '#444444',
  },
  -- omitting irrelevant parts...
}
```

I used to get:
<img width="1440" alt="before" src="https://user-images.githubusercontent.com/761254/137430890-b8393e0e-1f89-44d1-9200-0782100b6463.png">

Now I get:
<img width="1440" alt="after" src="https://user-images.githubusercontent.com/761254/137430949-8dd4c299-a44c-43cb-ad23-3d8c87b21466.png">

And I'm now exposing a new property called `inactive_bgcolor` that allows more control:
```lua
require('stabline').setup {
  defaults = {
    bg = '#d5c4a1',
    inactive_color = '#444444',
    inactive_bgcolor = 'gray',
    -- omitting irrelevant parts...
  },
  mode_colors = {
    ['n'] = '#444444',
  },
  -- omitting irrelevant parts...
}
```

With the settings above I get:
<img width="1440" alt="after2" src="https://user-images.githubusercontent.com/761254/137431416-086dfe47-c17a-470b-8b9c-769dcc40a7e2.png">

By default, `inactive_bgcolor` is set to `"none"`, which is the same default value of `bg`, therefore I expect `call_highlights` to function in the same way as before. This should help maintain backwards compatibility.