### PR TITLE
New Features + Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ require('staline').setup {
 		full_path       = false
 		font_active     = "none",     -- "bold", "italic", "bold,italic", etc
 		true_colors     = false       -- true lsp colors.
+		mod_symbol      = "  ",
 	},
 	mode_colors = {
 		n = "#2bbb4f",
@@ -91,6 +92,7 @@ To know more about colors and highlights, check [highlights wiki](https://github
 | right_sep    | single right separator |
 | left_sep_double     | Double left separator with a shade of gray |
 | right_sep_double    | Double right separator with a shade of gray |
+| cwd | Current working directory |
 
 > `lsp`, `lsp_name`, `file_size` are not included in the default settings.
 
@@ -127,7 +129,7 @@ Check out [wiki](https://github.com/tamton-aquib/staline.nvim/wiki) to see some 
 			style       = "bar", -- others: arrow, slant, bubble
 			stab_left   = "┃",   -- 😬
 			stab_right  = " ",
-			
+
 			fg          = Default is fg of "Normal".
 			bg          = Default is bg of "Normal".
 			inactive_bg = "#1e2127",

--- a/lua/staline.lua
+++ b/lua/staline.lua
@@ -64,7 +64,7 @@ local function lsp_client_name()
 	for _, client in pairs(vim.lsp.buf_get_clients(0)) do
 		clients[#clients+1] = t.lsp_client_symbol .. client.name
 	end
-	return table.concat(clients)
+	return table.concat(clients, ' ')
 end
 
 -- TODO: should this be changed to {'section', fg, bg} ?

--- a/lua/tables.lua
+++ b/lua/tables.lua
@@ -29,6 +29,7 @@ Tables = {
 		inactive_bgcolor = "none",
 		font_active = "none",          -- bold,italic etc.
 		true_colors = false,
+		mod_symbol      = "  ",
 		lsp_client_symbol = " "
 	},
 
@@ -39,6 +40,8 @@ Tables = {
 		help = { 'Help', '龎' },
 		qf = { "QuickFix", " " },
 		alpha = { "Alpha", "  " },
+		Jaq = { "Jaq", "  "},
+		Fm = { "Fm", "  "},
 		TelescopePrompt = { 'Telescope', "  " },
 	},
 


### PR DESCRIPTION
#### Update the README:
Address the changes made in this PR.

#### Bug with Floating Windows:
When using `special filetypes` with certain floating windows, `staline` would render itself for the buffer/file behind the floating window instead of the actual floating window. This commit fixes that and slightly decreases the LOC needed to do this.

#### Section Updates:

1. The `lsp_name` section would only show the first client used in a neovim session and wouldn't update after a new client was used.
2. Add `cwd` section that uses `vim.fn.fnamemodify(vim.fn.getcwd(), ':t')` to get the cwd.

#### Modified Icon Option:
Now the user can modify the icon shown to the right of the `file_name` section with the `mod_symbol` option.

#### New Filetypes:
Add filetypes for:

1. [jaq-nvim](https://github.com/is0n/jaq-nvim)
2. [fm-nvim](https://github.com/is0n/fm-nvim)

and since staline should render correctly when using a floating window, plugins like [nvim-toggleterm.lua](https://github.com/akinsho/nvim-toggleterm.lua) and [FTerm.nvim](https://github.com/numToStr/FTerm.nvim) that use a floating window should be supported.