### PR TITLE
added support for expanding null-ls sources

### DIFF
--- a/lua/staline/config.lua
+++ b/lua/staline/config.lua
@@ -12,6 +12,7 @@ Tables = {
     lsp_symbols = { Error=" ", Info=" ", Warn=" ", Hint="" },
 
     defaults = {
+        expand_null_ls = false,
         left_separator = "",
         right_separator = "",
         line_column = " [%l/%L] :%c 並%p%% ",


### PR DESCRIPTION
Hi everyone, I wanted to see the individual null-ls sources as part of the `lsp_name` section so I tried adding it in.
The expansion can be activated by setting the `expand_null_ls` key to true in the defaults table during setup.
i.e. 
```lua
require('staline').setup {
  defaults = {
    expand_null_ls = true,
    ...
  }
}
```

With `expand_null_ls` set to `true`:

<img width="1419" alt="image" src="https://user-images.githubusercontent.com/87934749/174011129-6cadc6a6-3ea0-431d-a82d-2e86d7386ab8.png">
<img width="1419" alt="image" src="https://user-images.githubusercontent.com/87934749/174011824-99eedb19-27cd-482e-ab79-4fa958014749.png">

With `expand_null_ls` set to `false`:

<img width="1419" alt="image" src="https://user-images.githubusercontent.com/87934749/174013205-4526379d-c134-4070-b8c4-59d736be12dd.png">

_The 'LSP: ' part is not part of the lsp_name section_

It can be a bit messy if there are too many null-ls sources but I think it can be made better by filtering out the sources by their methods (diagnostics, formatting etc.).

What do you guys think?