### PR TITLE
Add LSP client name truncation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ require('staline').setup()
 ```
 > <details>
 > <summary> Click to see default configuration </summary>
-> 
+>
 > ```lua
 > require('staline').setup {
 >     defaults = {
@@ -39,16 +39,17 @@ require('staline').setup()
 >         right_separator = "",
 >         full_path       = false,
 >         line_column     = "[%l/%L] :%c 並%p%% ", -- `:h stl` to see all flags.
-> 
+>
 >         fg              = "#000000",  -- Foreground text color.
 >         bg              = "none",     -- Default background is transparent.
 >         inactive_color  = "#303030",
 >         inactive_bgcolor = "none",
 >         true_colors     = false,      -- true lsp colors.
 >         font_active     = "none",     -- "bold", "italic", "bold,italic", etc
-> 
+>
 >         mod_symbol      = "  ",
 >         lsp_client_symbol = " ",
+>         lsp_client_character_name = "12", -- To shorten LSP client name list.
 >         branch_symbol   = " ",
 >         cool_symbol     = " ",       -- Change this to override default OS icon.
 >         null_ls_symbol = "",          -- A symbol to indicate that a source is coming from null-ls
@@ -90,7 +91,7 @@ require('staline').setup()
 > </details>
 
 > <details><summary>Sections</summary>
-> 
+>
 > | section | use |
 > |---------|-----|
 > | mode         | shows the mode       |
@@ -162,13 +163,13 @@ Check out [wiki](https://github.com/tamton-aquib/staline.nvim/wiki) to see some 
 >       style       = "bar", -- others: arrow, slant, bubble
 >       stab_left   = "┃",
 >       stab_right  = " ",
-> 
+>
 >       -- fg       = Default is fg of "Normal".
 >       -- bg       = Default is bg of "Normal".
 >       inactive_bg = "#1e2127",
 >       inactive_fg = "#aaaaaa",
 >       -- stab_bg  = Default is darker version of bg.,
-> 
+>
 >       font_active = "bold",
 >       exclude_fts = { 'NvimTree', 'dashboard', 'lir' },
 >       stab_start  = "",   -- The starting of stabline
@@ -182,9 +183,9 @@ Check out [wiki](https://github.com/tamton-aquib/staline.nvim/wiki) to see some 
 
 
 > <details> <summary>My personal config as of editing this file</summary>
-> 
+>
 > ![my stabline config](https://i.imgur.com/cmBdfzx.png)
-> 
+>
 > ```lua
 > require('stabline').setup {
 >     style = "slant",
@@ -193,7 +194,7 @@ Check out [wiki](https://github.com/tamton-aquib/staline.nvim/wiki) to see some 
 >     stab_right = "",
 > }
 > ```
-> 
+>
 > </details>
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ require('staline').setup()
 >
 >         mod_symbol      = "  ",
 >         lsp_client_symbol = " ",
->         lsp_client_character_name = 12, -- To shorten LSP client name list.
+>         lsp_client_character_length = 12, -- Shorten LSP client names.
 >         branch_symbol   = " ",
 >         cool_symbol     = " ",       -- Change this to override default OS icon.
 >         null_ls_symbol = "",          -- A symbol to indicate that a source is coming from null-ls

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ require('staline').setup()
 >
 >         mod_symbol      = "  ",
 >         lsp_client_symbol = " ",
->         lsp_client_character_name = "12", -- To shorten LSP client name list.
+>         lsp_client_character_name = 12, -- To shorten LSP client name list.
 >         branch_symbol   = " ",
 >         cool_symbol     = " ",       -- Change this to override default OS icon.
 >         null_ls_symbol = "",          -- A symbol to indicate that a source is coming from null-ls

--- a/lua/staline.lua
+++ b/lua/staline.lua
@@ -77,7 +77,7 @@ local lsp_client_name = function()
     local clients = {}
     local clients_name = ""
     local the_symbol = t.lsp_client_symbol
-    local name_max_lenght = t.lsp_client_character_name
+    local name_max_length = t.lsp_client_character_length
 
     for _, client in pairs(vim.lsp.get_active_clients()) do
         if t.expand_null_ls then
@@ -95,17 +95,17 @@ local lsp_client_name = function()
     clients_name = table.concat(clients, ', ')
 
     -- NOTE: Only show XX characters if the "clients_name" is too long
-    if name_max_lenght <= 0 then
+    if name_max_length <= 0 then
         return the_symbol .. clients_name
     else
-        local clients_lenght = string.len(clients_name)
-        local clients_truncateName = ""
+        local clients_length = string.len(clients_name)
+        local clients_truncated_name = ""
 
-        if clients_lenght >= name_max_lenght then
-            clients_truncateName = string.sub(clients_name, 1, name_max_lenght)
-            clients_truncateName = #clients .. ":(" .. clients_truncateName .. "...)"
-            return the_symbol .. clients_truncateName
-        elseif clients_lenght == 0 then
+        if clients_length >= name_max_length then
+            clients_truncated_name = string.sub(clients_name, 1, name_max_length)
+            clients_truncated_name = #clients .. ":(" .. clients_truncated_name .. "...)"
+            return the_symbol .. clients_truncated_name
+        elseif clients_length == 0 then
             return the_symbol .. #clients .. ":(" .. "LSP" .. ")"
         else
             return the_symbol .. #clients .. ":(" .. clients_name .. ")"

--- a/lua/staline.lua
+++ b/lua/staline.lua
@@ -75,6 +75,10 @@ end
 
 local lsp_client_name = function()
     local clients = {}
+    local clients_name = ""
+    local the_symbol = t.lsp_client_symbol
+    local name_max_lenght = t.lsp_client_character_name
+
     for _, client in pairs(vim.lsp.get_active_clients()) do
         if t.expand_null_ls then
             if client.name == 'null-ls' then
@@ -88,8 +92,24 @@ local lsp_client_name = function()
             clients[#clients + 1] = client.name
         end
     end
-    return t.lsp_client_symbol .. table.concat(clients, ', ')
+    clients_name = table.concat(clients, ', ')
+
+    -- NOTE: Only show XX characters if the "clients_name" is too long
+    if name_max_lenght <= 0 then
+        return the_symbol .. clients_name
+    else
+        local clients_lenght = string.len(clients_name)
+        local clients_truncateName = ""
+
+        if clients_lenght >= name_max_lenght then
+            clients_truncateName = string.sub(clients_name, 1, name_max_lenght)
+            clients_truncateName = #clients .. ":(" .. clients_truncateName .. "...)"
+            return the_symbol .. clients_truncateName
+        end
+        return the_symbol .. #clients .. ":(" .. "LSP" .. ")"
+    end
 end
+
 
 -- TODO: check colors inside function type
 local parse_section = function(section)

--- a/lua/staline.lua
+++ b/lua/staline.lua
@@ -105,8 +105,11 @@ local lsp_client_name = function()
             clients_truncateName = string.sub(clients_name, 1, name_max_lenght)
             clients_truncateName = #clients .. ":(" .. clients_truncateName .. "...)"
             return the_symbol .. clients_truncateName
+        elseif clients_lenght == 0 then
+            return the_symbol .. #clients .. ":(" .. "LSP" .. ")"
+        else
+            return the_symbol .. #clients .. ":(" .. clients_name .. ")"
         end
-        return the_symbol .. #clients .. ":(" .. "LSP" .. ")"
     end
 end
 

--- a/lua/staline/config.lua
+++ b/lua/staline/config.lua
@@ -34,6 +34,7 @@ return {
         branch_symbol = " ",
         mod_symbol = "  ",
         lsp_client_symbol = " ",
+        lsp_client_character_name = 12,
         null_ls_symbol = "",
     },
 

--- a/lua/staline/config.lua
+++ b/lua/staline/config.lua
@@ -34,7 +34,7 @@ return {
         branch_symbol = " ",
         mod_symbol = "  ",
         lsp_client_symbol = " ",
-        lsp_client_character_name = 12,
+        lsp_client_character_length = 12,
         null_ls_symbol = "",
     },
 


### PR DESCRIPTION
Hello! How are you? I created this small functionality for **staline.nvim**.

I like the `lsp_name` section, but I had the inconvenience that every LSP client is activated when navigating between different files, causing the `lsp_name` list of names to grow and grow, ruining the appearance of `staline`.

My solution was to add the `lsp_client_character_name` option to the configuration file and expand the features of `lsp_name`, so that by adding a certain value to `lsp_client_character_name`, the list of names would be truncated and a number indicating how many clients are active would be displayed.

That is:

```lua
require('staline').setup {
  defaults = {
    lsp_client_character_name = 12,
    ...
    }
}
```

With `lsp_client_character_name = 0`.
![lsp_name_OFF](https://github.com/tamton-aquib/staline.nvim/assets/54963296/b2739175-50f8-4346-8a47-05ef1b529caf)

With `lsp_client_character_name = 12`.
![lsp_name_ON-2](https://github.com/tamton-aquib/staline.nvim/assets/54963296/755771b7-e4af-4288-bd3b-8a96c34fd9bd)

With `lsp_client_character_name = 12` when the LSP client is not detected.
![lsp_name_ON-1](https://github.com/tamton-aquib/staline.nvim/assets/54963296/c04ccfc6-9338-4185-8c93-39e8ee2c8fa8)

*The icon is part of `lsp_client_symbol`.*

What do you think?