### PR TITLE
Fix icons for nerd-fonts 3.0 update

### DIFF
--- a/lua/staline.lua
+++ b/lua/staline.lua
@@ -159,7 +159,7 @@ M.get_statusline = function(status)
     local mode = vim.api.nvim_get_mode()['mode']
     local fgColor = status and conf.mode_colors[mode] or t.inactive_color
     local bgColor = status and t.bg or t.inactive_bgcolor
-    local modeIcon = conf.mode_icons[mode] or " "
+    local modeIcon = conf.mode_icons[mode] or "󰋜 "
 
     local f_name = t.full_path and '%F' or '%t'
     -- TODO: original color of icon

--- a/lua/staline/config.lua
+++ b/lua/staline/config.lua
@@ -32,7 +32,7 @@ return {
 
         cool_symbol = util.system_icon(),
         branch_symbol = " ",
-        mod_symbol = "  ",
+        mod_symbol = " 󰏫 ",
         lsp_client_symbol = " ",
         lsp_client_character_length = 12,
         null_ls_symbol = "",

--- a/lua/staline/config.lua
+++ b/lua/staline/config.lua
@@ -14,12 +14,12 @@ return {
         right = { 'line_column' }
     },
 
-    lsp_symbols = { Error=" ", Info=" ", Warn=" ", Hint="" },
+    lsp_symbols = { Error="󰅙 ", Info="󰋼 ", Warn=" ", Hint="" },
 
     defaults = {
         left_separator = "",
         right_separator = "",
-        line_column = " [%l/%L] :%c 並%p%% ",
+        line_column = " [%l/%L] :%c 󰕱 %p%% ",
         expand_null_ls = false,
         full_path = false,
 
@@ -42,7 +42,7 @@ return {
         NvimTree = { 'NvimTree', ' ' },
         packer = { 'Packer',' ' },
         dashboard = { 'Dashboard', '  ' },
-        help = { 'Help', '龎' },
+        help = { 'Help', '󰗚 ' },
         qf = { "QuickFix", " " },
         alpha = { "Alpha", "  " },
         Jaq = { "Jaq", "  "},
@@ -68,9 +68,9 @@ return {
     mode_icons = {
         ['n']='󰋜 ', ['no']='󰋜 ', ['niI']='󰋜 ', ['niR']='󰋜 ',
         ['no']='󰋜 ', ['niV']='󰋜 ', ['nov']='󰋜 ', ['noV']='󰋜 ',
-        ['i']=' ', ['ic']=' ', ['ix']=' ', ['s']=' ', ['S']=' ',
-        ['v']=' ', ['V']=' ', ['']=' ',
-        ['r']='﯒ ', ['r?']=' ', ['c']=' ',
+        ['i']='󰏫 ', ['ic']='󰏫 ', ['ix']='󰏫 ', ['s']='󰏫 ', ['S']='󰏫 ',
+        ['v']='󰈈 ', ['V']='󰈈 ', ['']='󰈈 ',
+        ['r']='󰛔 ', ['r?']=' ', ['c']=' ',
         ['t']=' ', ['!']=' ', ['R']=' ',
     },
 

--- a/lua/staline/utils.lua
+++ b/lua/staline/utils.lua
@@ -26,7 +26,7 @@ U.colorize = function(n, fg, bg, style)
 end
 
 U.system_icon = function()
-    if vim.fn.has("win32")    == 1 then return "者"
+    if vim.fn.has("win32")    == 1 then return " "
     elseif vim.fn.has("mac")  == 1 then return " "
     elseif vim.fn.has("unix") == 1 then return " "
     end


### PR DESCRIPTION
With the new nerd font's 3.0 update, material icon font's were moves, leaving empty boxes in their place.

This pull request hopes to fix that.