### PR TITLE
Replace deprecated API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ TLDR;<br/> staline(**sta**tus**line**): A simple statusline for neovim written i
 stabline(s-**tabline**): A simple bufferline for neovim written in lua. (sry didnt get a better name.)
 
 ### Requirements
-* Requires neovim version >= 0.7
+* Requires neovim version >= 0.10
 * `vim.opt.laststatus=2` in your init.lua for statusline. (or `3` for global line)
 * `vim.opt.showtabline=2` in your init.lua for bufferline.
 * `vim.opt.termguicolors = true` must be set.

--- a/lua/staline/init.lua
+++ b/lua/staline/init.lua
@@ -81,7 +81,7 @@ local lsp_client_name = function()
     local the_symbol = t.lsp_client_symbol
     local name_max_length = t.lsp_client_character_length
 
-    for _, client in pairs(vim.lsp.get_active_clients()) do -- Deprecated?
+    for _, client in pairs(vim.lsp.get_clients()) do
         if t.expand_null_ls then
             if client.name == 'null-ls' then
                 for _, source in pairs(get_attached_null_ls_sources()) do


### PR DESCRIPTION
Since neovim v0.10 the API call [`vim.lsp.get_active_clients`](https://github.com/neovim/neovim/blob/v0.10.0/runtime/lua/vim/lsp.lua#L784) was deprecated and replaced by the function call [`vim.lsp.get_clients`](https://github.com/neovim/neovim/blob/v0.10.0/runtime/lua/vim/lsp.lua#L758).

This seems to be already known since there was a comment in the code about it and I assume this was done to be compatible with older neovim version, but for me it now bubbles up as a warning each time I start neovim.