### PR TITLE
(feat)stabline: add option for modified buffer icon color (and related fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,19 +164,20 @@ Check out [wiki](https://github.com/tamton-aquib/staline.nvim/wiki) to see some 
 >       stab_left   = "┃",
 >       stab_right  = " ",
 >
->       -- fg       = Default is fg of "Normal".
->       -- bg       = Default is bg of "Normal".
+>       -- fg       = -- Default is fg of "Normal".
+>       -- bg       = -- Default is bg of "Normal".
 >       inactive_bg = "#1e2127",
 >       inactive_fg = "#aaaaaa",
->       -- stab_bg  = Default is darker version of bg.,
+>       -- stab_bg  = -- Default is darker version of bg.,
+>       mod_symbol  = ' '
+>       mod_color   = "#ffb000",
 >
 >       font_active = "bold",
 >       exclude_fts = { 'NvimTree', 'dashboard', 'lir' },
 >       stab_start  = "",   -- The starting of stabline
 >       stab_end    = "",
->       numbers = function(bufn, n)
->           return '*'..n..' '
->       end
+>       padding     = 0,
+>       numbers = false  -- others: count, buf, function(bufn, n) return '*'..n..' ' end
 > 	}
 >   ```
 > </details>
@@ -192,6 +193,8 @@ Check out [wiki](https://github.com/tamton-aquib/staline.nvim/wiki) to see some 
 >     bg = "#986fec",
 >     fg = "black",
 >     stab_right = "",
+>     font_active = "none",
+>     stab_bg = "none"
 > }
 > ```
 >

--- a/lua/stabline.lua
+++ b/lua/stabline.lua
@@ -2,7 +2,13 @@ local Stabline = {}
 local util = require("staline.utils")
 local stabline_loaded
 local normal_bg, normal_fg
-local opts = { style='bar', exclude_fts={'NvimTree', 'help', 'dashboard', 'lir', 'alpha'}, numbers=nil }
+local opts = {
+    style = 'bar',
+    exclude_fts = {'NvimTree', 'help', 'dashboard', 'lir', 'alpha'},
+    numbers = nil,
+    mod_symbol = ' ',
+    mod_color = '#ffb000'
+}
 -- NOTE: other opts: fg, bg, stab_start, stab_end, stab_right, stab_left, stab_bg, inactive_bg, inactive_fg
 
 local type_chars={ bar={left="┃", right=" "}, slant={left="", right=""}, arrow={left="", right=""}, bubble={left="", right=""} }
@@ -44,6 +50,8 @@ local refresh_colors = function()
     util.colorize('StablineInactive', inactive_fg, inactive_bg, opts.font_inactive)
     util.colorize('StablineInactiveRight', inactive.right.f, inactive.right.b)
     util.colorize('StablineInactiveLeft', inactive.left.f, inactive.left.b)
+    util.colorize('StablineModified', opts.mod_color, bg_hex)
+    util.colorize('StablineModifiedInactive', opts.mod_color, inactive_bg)
 end
 
 Stabline.setup = function(setup_opts)
@@ -79,9 +87,9 @@ Stabline.get_tabline = function()
     local counter = 1
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
         if vim.api.nvim_buf_is_valid(buf) and vim.bo[buf].buflisted then
-            local edited = vim.bo.modified and "" or " "
+            local edited = vim.bo[buf].modified
 
-            local f_name = vim.api.nvim_buf_get_name(buf):match("^.+[\\/](.+)$") or "" -- TODO: use fnamemodify()?
+            local f_name = vim.api.nvim_buf_get_name(buf):match("^.+[\\/](.+)$") or "[NEW]" -- TODO: use fnamemodify()?
             local ext = string.match(f_name, "%w+%.(.+)")
             local f_icon, icon_hl = util.get_file_icon(f_name, ext)
 
@@ -98,9 +106,11 @@ Stabline.get_tabline = function()
             "%"..buf.."@v:lua.PickBuffer@".. -- start for picking buffer
             get_number_format(buf, counter)..
             (s and do_icon_hl(icon_hl) or "")..f_icon.." "..
-            "%#Stabline"..(s and "Sel" or "Inactive").."#"..f_name.." "..
+            "%#Stabline"..(s and "Sel" or "Inactive").."#"..f_name..
+            (edited and "%#StablineModified"..(s and "#" or "Inactive#") or "")..
+            (edited and opts.mod_symbol.." " or "  ")..
             "%X".. -- end for picking buffer
-            (" "):rep(opts.padding or 0).. (s and edited or " ")..
+            (" "):rep(opts.padding or 0)..
             "%#Stabline"..(s and "" or "Inactive").."Right#"..stab_right
 
             counter = counter + 1

--- a/lua/stabline.lua
+++ b/lua/stabline.lua
@@ -13,9 +13,23 @@ local opts = {
 
 local type_chars={ bar={left="┃", right=" "}, slant={left="", right=""}, arrow={left="", right=""}, bubble={left="", right=""} }
 
-function PickBuffer(buf_id)
+function BufferClick(buf_id, _, button)
    local window = vim.api.nvim_get_current_win()
-   vim.api.nvim_win_set_buf(window, buf_id)
+
+   if button == 'l' then
+       vim.api.nvim_win_set_buf(window, buf_id)
+       return
+   end
+
+   if button ~= 'm' then return end
+   if vim.bo[buf_id].modified then
+       vim.notify('Buffer has unsaved changes', 'WARN', { title = 'staline.nvim' })
+       return
+   end
+   if vim.api.nvim_get_current_buf() == buf_id then
+       vim.cmd('bnext')
+   end
+   vim.api.nvim_buf_delete(buf_id, {})
 end
 
 local refresh_colors = function()
@@ -103,13 +117,13 @@ Stabline.get_tabline = function()
             "%#Stabline"..(s and "" or "Inactive").."Left#"..stab_left..
             "%#Stabline"..(s and "Sel" or "Inactive").."#   "..
             (" "):rep(opts.padding or 0)..
-            "%"..buf.."@v:lua.PickBuffer@".. -- start for picking buffer
+            "%"..buf.."@v:lua.BufferClick@".. -- start for buffer click handle
             get_number_format(buf, counter)..
             (s and do_icon_hl(icon_hl) or "")..f_icon.." "..
             "%#Stabline"..(s and "Sel" or "Inactive").."#"..f_name..
             (edited and "%#StablineModified"..(s and "#" or "Inactive#") or "")..
             (edited and opts.mod_symbol.." " or "  ")..
-            "%X".. -- end for picking buffer
+            "%X".. -- end for buffer click handle
             (" "):rep(opts.padding or 0)..
             "%#Stabline"..(s and "" or "Inactive").."Right#"..stab_right
 


### PR DESCRIPTION
Hi, thanks for the lightweight plugin. It helped me get away from the other bufferline plugin (which is now a bloated mess!). I've made these modifications. It's not as huge as it may seem -- I just felt like properly listing all the changes :)

- add modified buffer icon color option
- add 2 hl classes: StablineModified{,Inactive}
- fix new buffers (:[v]new) not showing in the bufferline
  - use '[NEW]' as the fallback name
- fix modified buffer icon not showing when user is in different buffer
- fix modified icon being cut off at the end due to nerdfont width
- align the icon to middle (stick to buffername) instead of end
- fix README.md
  - add mod_symbol and mod_color as new option names
  - add undocumented option "padding"
  - change "numbers" option to "none" as it's not enabled by default
  - add font_active and stab_bg = "none" to reproduce the preview in author's screenshot

Edit:
- middle mouse click on tab to delete buffer